### PR TITLE
Removed E-Stop Functionality

### DIFF
--- a/ExoCode/src/Exo.cpp
+++ b/ExoCode/src/Exo.cpp
@@ -76,7 +76,8 @@ bool Exo::run()
         bool trial_running = sync_led.get_is_blinking();
 
         //Check the estop
-        data->estop = digitalRead(logic_micro_pins::motor_stop_pin);
+        data->estop = 0;    // By default, the estop functionality is disabled. To enable it, comment this line out and uncomment the line below.
+        //data->estop = digitalRead(logic_micro_pins::motor_stop_pin);
 
         //If the estop is low, disable all of the motors
         if (data->estop)


### PR DESCRIPTION
Set data->estop = 0 in Exo.cpp to disable estop functionality. If you wish to re-enable the functionality, comment "data->estop = 0" and uncomment the line immediately below.