### PR TITLE
Modified OpenExo_Board_V0_6_Maxon to match PCBA pin configs

### DIFF
--- a/ExoCode/src/Board.h
+++ b/ExoCode/src/Board.h
@@ -467,10 +467,10 @@
 			 #if defined(ARDUINO_TEENSY41)
 				//Maxon motor Pins
 				const unsigned int maxon_err_right_pin = 37;
-				const unsigned int maxon_err_left_pin = 37;
-				const unsigned int maxon_ctrl_left_pin = not_connected_pin;
+				const unsigned int maxon_err_left_pin = 36;
+				const unsigned int maxon_ctrl_left_pin = A8;
 				const unsigned int maxon_ctrl_right_pin = A9;
-				const unsigned int maxon_current_left_pin = not_connected_pin;
+				const unsigned int maxon_current_left_pin = A0;
 				const unsigned int maxon_current_right_pin = A1;
 				const unsigned int maxon_pwm_neutral_val = 2048;
 				const unsigned int maxon_pwm_u_bound = 3690;
@@ -483,31 +483,34 @@
 				const unsigned int volt_sense = not_connected_pin;
 			 
 				//Serial Pins, NC
-				const unsigned int rx1_pin = not_connected_pin;
-				const unsigned int tx1_pin = not_connected_pin;
+				const unsigned int rx1_pin = 35;
+				const unsigned int tx1_pin = 34;
 				
 				//CAN Pins
 				const unsigned int can_rx_pin = not_connected_pin;
 				const unsigned int can_tx_pin = not_connected_pin;
 				
 				//FSR Pins
-				const unsigned int fsr_sense_left_heel_pin = not_connected_pin;
-				const unsigned int fsr_sense_left_toe_pin = not_connected_pin;
-				const unsigned int fsr_sense_right_heel_pin= 17;
-				const unsigned int fsr_sense_right_toe_pin = 16;
+				const unsigned int fsr_sense_left_heel_pin = A14;
+				const unsigned int fsr_sense_left_toe_pin = A15;
+				const unsigned int fsr_sense_right_heel_pin= A3;
+				const unsigned int fsr_sense_right_toe_pin = A2;
 				
 				//Torque Sensor Pins (This will need to be updated/fixed)
 				const unsigned int num_available_joints = 2;
 				//const unsigned int torque_sensor_left[] = {A16, A17};
-				const unsigned int torque_sensor_left[] = {A6};
+				const unsigned int torque_sensor_left[] = {A16};
 				//const unsigned int torque_sensor_left1 = A16;
 				//const unsigned int torque_sensor_right[] = {A6, A7};
 				const unsigned int torque_sensor_right[] = {A6};
 				//const unsigned int torque_sensor_right1 = A8;
 				
 				//Sync LED Pins
-				const unsigned int sync_led_pin = not_connected_pin;
+				const unsigned int sync_led_pin = A17;
 				const unsigned int sync_default_pin = not_connected_pin;
+
+                const unsigned int SmBusSDA = A4;
+                const unsigned int SmBusSCL = A5;
 			#endif
 			
             //Arduino compiles all files not just the ones that are used so this is not under teensy to prevent errors
@@ -516,9 +519,9 @@
 
 			 #if defined(ARDUINO_TEENSY41)
 				//Status LED Pins
-				const unsigned int status_led_r_pin = not_connected_pin;
-				const unsigned int status_led_g_pin = not_connected_pin;
-				const unsigned int status_led_b_pin = not_connected_pin;
+				const unsigned int status_led_r_pin = A7;
+				const unsigned int status_led_g_pin = A10;
+				const unsigned int status_led_b_pin = A11;
 			#endif
 
 			//If you have connected to pins with PWM set to true.
@@ -547,8 +550,8 @@
 				
 				const unsigned int speed_check_pin = not_connected_pin;
 				
-				const unsigned int left_ankle_angle_pin = not_connected_pin;
-				const unsigned int right_ankle_angle_pin = A8;
+				const unsigned int left_ankle_angle_pin = A13;
+				const unsigned int right_ankle_angle_pin = A12;
 				
 				// I2C 
 				// SDA 18


### PR DESCRIPTION
The pin definition in the Board.h for the OpenExo_Board_V0_6_Maxon did not match the schematic for the associated Maxon compatible PCBAs on the OpenExo wiki. 

These changes update those pin configurations to match the schematic and be compatible with both the board designs available on the wiki and the OpenExo retrofit kit used on Biomotum Spark V2 devices. 

This has been tested on a Spark V2 device with Maxon motors/drivers and an OpenExo retrofit kit installed.